### PR TITLE
Fix misleading error message for size_limit_in_bytes validation

### DIFF
--- a/atomic_lru/_storage/storage.py
+++ b/atomic_lru/_storage/storage.py
@@ -100,7 +100,7 @@ class Storage(Generic[T]):
     def __post_init__(self) -> None:
         # Validate configuration before allocating any resources
         if self.size_limit_in_bytes is not None and self.size_limit_in_bytes < 4096:
-            raise ValueError("size_limit_in_bytes must be greater than 4096")
+            raise ValueError("size_limit_in_bytes must be at least 4096")
 
         self._size_in_bytes = sys.getsizeof(self._data)
         if not self.expiration_disabled:

--- a/backlog/tasks/task-8 - Bug-Misleading-error-message-for-`size_limit_in_bytes`-validation.md
+++ b/backlog/tasks/task-8 - Bug-Misleading-error-message-for-`size_limit_in_bytes`-validation.md
@@ -1,13 +1,14 @@
 ---
 id: TASK-8
 title: 'Bug: Misleading error message for `size_limit_in_bytes` validation'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-02-20 14:14'
-updated_date: '2026-02-20 14:20'
+updated_date: '2026-02-20 14:30'
 labels:
   - Bug
   - Planned
+  - Implemented
 dependencies: []
 references:
   - atomic_lru/_storage/storage.py


### PR DESCRIPTION
## Summary

- Fixed misleading error message in `Storage.__post_init__()` where the validation for `size_limit_in_bytes` checked `< 4096` (allowing 4096 as a valid value) but the error message said "must be greater than 4096", implying 4096 is invalid.
- Changed the message to "must be at least 4096" to accurately reflect the `>= 4096` constraint.

## Test plan

- [x] All 30 existing tests pass (`make test`)
- [x] Linting passes (`make lint`)
- [x] Documentation generation passes (`make doc`)

Closes TASK-8

Made with [Cursor](https://cursor.com)