### PR TITLE
Fix set() not updating LRU position when overwriting an existing key

### DIFF
--- a/atomic_lru/_storage/storage.py
+++ b/atomic_lru/_storage/storage.py
@@ -302,8 +302,9 @@ class Storage(Generic[T]):
                     value_obj.size_in_bytes + PER_ITEM_APPROXIMATE_SIZE
                 )
 
-            # Store the value (moves to end of OrderedDict for LRU)
+            # Store the value and ensure it's at the end of the LRU order (most recently used)
             self._data[key] = value_obj
+            self._data.move_to_end(key)
 
     def get(self, key: str) -> T | CacheMissSentinel:
         """Retrieve a value from the cache.

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -197,6 +197,28 @@ def test_cache_lru_behavior():
     assert cache.get("key4") == "value4"  # Should be there
 
 
+def test_cache_lru_behavior_with_set_overwrite():
+    cache = Cache(max_items=3, size_limit_in_bytes=None, default_ttl=None)
+
+    cache.set("key1", "value1")
+    cache.set("key2", "value2")
+    cache.set("key3", "value3")
+
+    assert cache.number_of_items == 3
+
+    # Overwrite key1 via set() — this should move it to most recently used
+    cache.set("key1", "value1_updated")
+
+    # Add key4, should evict key2 (least recently used)
+    cache.set("key4", "value4")
+
+    assert cache.number_of_items == 3
+    assert cache.get("key1") == "value1_updated"  # Should still be there
+    assert cache.get("key2") is CACHE_MISS  # Should be evicted
+    assert cache.get("key3") == "value3"  # Should still be there
+    assert cache.get("key4") == "value4"  # Should be there
+
+
 def test_cache_size_limit():
     cache = Cache(size_limit_in_bytes=8192, max_items=100, default_ttl=None)
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -357,3 +357,48 @@ def test_clear_closed_storage():
 
     with pytest.raises(RuntimeError, match="Storage is closed"):
         storage.clear()
+
+
+def test_overwrite_existing_key_updates_lru_position():
+    """Overwriting a key via set() should move it to the most recently used position."""
+    storage = Storage[bytes](size_limit_in_bytes=None, max_items=3)
+
+    storage.set("a", b"a")
+    storage.set("b", b"b")
+    storage.set("c", b"c")
+
+    # Overwrite "a" — it should now be the most recently used
+    storage.set("a", b"a2")
+
+    # Adding "d" must evict "b" (oldest), not "a"
+    storage.set("d", b"d")
+
+    assert storage.get("a") == b"a2"  # should still be present
+    assert storage.get("b") is CACHE_MISS  # evicted (LRU)
+    assert storage.get("c") == b"c"
+    assert storage.get("d") == b"d"
+
+    storage.close()
+
+
+def test_overwrite_existing_key_updates_lru_position_with_multiple_overwrites():
+    """Multiple set() overwrites correctly track the least recently used key."""
+    storage = Storage[bytes](size_limit_in_bytes=None, max_items=3)
+
+    storage.set("a", b"a")
+    storage.set("b", b"b")
+    storage.set("c", b"c")
+
+    # Overwrite "b" then "a" — "c" becomes the oldest
+    storage.set("b", b"b2")
+    storage.set("a", b"a2")
+
+    # Adding "d" must evict "c" (actual LRU)
+    storage.set("d", b"d")
+
+    assert storage.get("a") == b"a2"
+    assert storage.get("b") == b"b2"
+    assert storage.get("c") is CACHE_MISS  # evicted (LRU)
+    assert storage.get("d") == b"d"
+
+    storage.close()


### PR DESCRIPTION
## Summary

- `OrderedDict.__setitem__` does not reorder existing keys, so `set()` overwrites left a key at its original LRU position instead of marking it most-recently-used
- Added `self._data.move_to_end(key)` after the assignment in `storage.py`; this is a no-op for new keys so it is safe unconditionally
- Added 3 new tests (2 in `test_storage.py`, 1 in `test_cache.py`) verifying correct LRU positioning and eviction after `set()` overwrites

## Test plan

- [ ] `make lint` passes
- [ ] `make test` passes (33 tests, including 3 new ones)
- [ ] `make doc` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)