### PR TITLE
Fix size tracking when set() overwrites the LRU item

### DIFF
--- a/atomic_lru/_storage/storage.py
+++ b/atomic_lru/_storage/storage.py
@@ -290,6 +290,11 @@ class Storage(Generic[T]):
                 until_number_of_items=until_number_of_items,
             )
 
+            # Re-check: the key being overwritten may have been the LRU item and got evicted
+            if is_overwriting and key not in self._data:
+                is_overwriting = False
+                old_value_obj = None
+
             # Update size tracking: calculate net change instead of subtract then add
             if is_overwriting:
                 # Net change: new size - old size (PER_ITEM_APPROXIMATE_SIZE cancels out)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -402,3 +402,55 @@ def test_overwrite_existing_key_updates_lru_position_with_multiple_overwrites():
     assert storage.get("d") == b"d"
 
     storage.close()
+
+
+def test_overwrite_lru_item_size_tracking():
+    """Size tracking stays correct when set() overwrites a key that gets evicted as the LRU item.
+
+    Scenario: "A" is the LRU item. Calling set("A", larger_value) triggers eviction which
+    pops "A" itself (the LRU). The subsequent size accounting must treat the store as a fresh
+    insert, not an overwrite, to avoid double-subtracting the old size.
+    """
+    small_value = b"X" * 2000
+    large_value = b"Y" * 2100
+
+    small_value_obj = Value(value=small_value, ttl=None)
+    large_value_obj = Value(value=large_value, ttl=None)
+    item_total_small = small_value_obj.size_in_bytes + PER_ITEM_APPROXIMATE_SIZE
+    item_total_large = large_value_obj.size_in_bytes + PER_ITEM_APPROXIMATE_SIZE
+
+    # The storage starts with an OrderedDict overhead baked into _size_in_bytes.
+    # Use a throw-away storage instance to measure the initial overhead so we can
+    # set size_limit tightly enough that overwriting "A" triggers eviction of "A" itself.
+    _probe = Storage[bytes](size_limit_in_bytes=4096)
+    initial_overhead = _probe.size_in_bytes
+    _probe.close()
+
+    # Size limit that fits exactly the initial overhead plus two small items.
+    size_limit = initial_overhead + item_total_small * 2
+    assert size_limit >= 4096, "size_limit must meet the Storage minimum"
+    # large_value raw length must not exceed size_limit / 2 or Storage silently drops it
+    assert len(large_value) <= size_limit / 2
+
+    storage = Storage[bytes](size_limit_in_bytes=size_limit)
+
+    # Insert "A" first (it becomes the LRU), then "B"
+    storage.set("A", small_value)
+    storage.set("B", small_value)
+    assert storage.size_in_bytes == size_limit
+
+    # Overwrite "A" with a larger value — eviction will pop "A" (the LRU) to make room,
+    # then re-insert it as a fresh entry with the new value
+    storage.set("A", large_value)
+
+    # "A" must be retrievable with the new value
+    assert storage.get("A") == large_value
+
+    # "B" should still be present (it was not the LRU)
+    assert storage.get("B") == small_value
+
+    # Size must reflect the initial overhead plus one small item ("B") and one large item ("A")
+    expected_size = initial_overhead + item_total_small + item_total_large
+    assert storage.size_in_bytes == expected_size
+
+    storage.close()


### PR DESCRIPTION
## Summary

- Fixes size tracking corruption when `Storage.set()` overwrites a key that gets evicted as the LRU item during eviction
- Adds a re-check: when the key being overwritten was evicted and is no longer in the data, treat it as a fresh insert instead of an overwrite to avoid double-subtracting the old size
- Adds a regression test to verify the fix

## Changes

- `atomic_lru/_storage/storage.py`: Re-check after eviction loop; if the overwritten key was evicted, reset `is_overwriting` and `old_value_obj` to avoid incorrect size accounting
- `tests/test_storage.py`: Add `test_overwrite_lru_item_size_tracking()` to cover the edge case

## Related issues

Closes #16

Made with [Cursor](https://cursor.com)