### PR TITLE
Fix typo in Makefile serve-doc help text (Server -> Serve)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ doc: ## Generate the documentation
 	$(UV_RUN) mkdocs build --clean --strict
 
 .PHONY: serve-doc
-serve-doc: ## Server the documentation site
+serve-doc: ## Serve the documentation site
 	$(UV_RUN) mkdocs serve --watch docs
 
 .PHONY: set-version


### PR DESCRIPTION
## Description

Fixes a single-character typo in the `Makefile` `serve-doc` target help text.

**Before:** `serve-doc: ## Server the documentation site`
**After:** `serve-doc: ## Serve the documentation site`

"Server" (noun) was corrected to "Serve" (verb), which is the intended usage in this context.

Fixes #19

## Checklist

- [x] Tests pass (`make test`)
- [x] Linting passes (`make lint`)
- [x] Documentation generated (`make doc`)
