### PR TITLE
test: assert delete() return values (fixes #20)

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -246,14 +246,14 @@ def test_cache_delete():
     assert cache.number_of_items == 2
     assert cache.get("key1") == "value1"
 
-    cache.delete("key1")
+    assert cache.delete("key1") is True
 
     assert cache.number_of_items == 1
     assert cache.get("key1") is CACHE_MISS
     assert cache.get("key2") == "value2"
 
     # Delete non-existent key should do nothing
-    cache.delete("nonexistent")
+    assert cache.delete("nonexistent") is False
     assert cache.number_of_items == 1
 
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -199,7 +199,9 @@ def test_storage_various():
     assert str(y) == "<CacheMiss>"
 
     storage = Storage[bytes](expiration_thread_max_checks_per_iteration=0)
-    storage.delete("key1")  # delete a non-existing key should do nothing
+    assert (
+        storage.delete("key1") is False
+    )  # delete a non-existing key should do nothing
 
     storage.set("key1", b"v1", ttl=0.01)
 
@@ -207,6 +209,14 @@ def test_storage_various():
 
     # Get an expired key should return CACHE_MISS
     assert storage.get("key1") is CACHE_MISS
+
+
+def test_storage_delete_return_value():
+    storage = Storage[bytes](expiration_thread_max_checks_per_iteration=0)
+    storage.set("key1", b"v1")
+    assert storage.delete("key1") is True
+    assert storage.delete("key1") is False
+    storage.close()
 
 
 def test_non_bytes_storage():


### PR DESCRIPTION
## Summary

- In `tests/test_cache.py`, updated `test_cache_delete` to assert that `cache.delete("key1")` returns `True` (existing key) and `cache.delete("nonexistent")` returns `False` (non-existing key).
- In `tests/test_storage.py`, updated `test_storage_various` to assert that `storage.delete("key1")` returns `False` when the key does not exist.
- Added a new `test_storage_delete_return_value` function in `tests/test_storage.py` to verify `storage.delete()` returns `True` for existing keys and `False` after deletion.

Closes #20

## Test plan

- [x] `make lint` passes with no errors
- [x] `make test` passes with no failures (35 tests)

Made with [Cursor](https://cursor.com)