### PR TITLE
fix: raise ValueError in Cache.set() for oversized serialized values

### DIFF
--- a/atomic_lru/_cache.py
+++ b/atomic_lru/_cache.py
@@ -191,14 +191,25 @@ class Cache(Storage[bytes]):
 
         Raises:
             RuntimeError: If the cache has been closed.
-            ValueError: If serialization fails, or if size limits are set and
-                the serialized value is too large.
+            ValueError: If serialization fails, or if `size_limit_in_bytes` is
+                set and the serialized value exceeds half of `size_limit_in_bytes`
+                (items that large would be silently dropped by the underlying
+                storage, so an explicit error is raised instead).
 
         Note:
             The value is serialized before size checks are performed, so the
             serialized size is what counts toward size limits.
         """
         serialized_value = self._serialize(value)
+        if (
+            self.size_limit_in_bytes is not None
+            and len(serialized_value) > self.size_limit_in_bytes / 2
+        ):
+            raise ValueError(
+                f"Serialized value size ({len(serialized_value)} bytes) exceeds "
+                f"half of size_limit_in_bytes ({self.size_limit_in_bytes} bytes) "
+                "and would be silently dropped"
+            )
         super().set(key=key, value=serialized_value, ttl=ttl)
 
     def get(self, key: str) -> Any | CacheMissSentinel:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -229,11 +229,11 @@ def test_cache_size_limit():
     assert cache.number_of_items > 0
     assert cache.size_in_bytes < 8192
 
-    # Try to store a very large value
+    # Try to store a very large value — should raise ValueError (not silently drop)
     large_value = "x" * 10000
-    cache.set("large", large_value)
+    with pytest.raises(ValueError, match="exceeds half of size_limit_in_bytes"):
+        cache.set("large", large_value)
 
-    # Large value should be rejected (exceeds size_limit_in_bytes / 2)
     assert cache.get("large") is CACHE_MISS
 
 


### PR DESCRIPTION
## Description

`Cache.set()` documented that it raises `ValueError` when `size_limit_in_bytes` is set and the serialized value is too large. However, the underlying `Storage.set()` was silently returning without storing the value, causing silent data loss with no indication to the caller.

This PR fixes the mismatch by having `Cache.set()` explicitly check the serialized size before calling the parent method and raising a `ValueError` when the value exceeds half of `size_limit_in_bytes` — making actual behavior match the documented behavior.

The existing `test_cache_size_limit` test has been updated to expect a `ValueError` instead of a silent drop (`CACHE_MISS`).

Fixes #17

## Checklist

- [x] Tests pass (`make test`)
- [x] Linting passes (`make lint`)
- [ ] Documentation generated (`make doc`)
