### PR TITLE
docs: fix inaccurate ValueError claim for oversized values in set() docstrings

### DIFF
--- a/atomic_lru/_cache.py
+++ b/atomic_lru/_cache.py
@@ -191,12 +191,13 @@ class Cache(Storage[bytes]):
 
         Raises:
             RuntimeError: If the cache has been closed.
-            ValueError: If serialization fails, or if size limits are set and
-                the serialized value is too large.
+            ValueError: If serialization fails.
 
         Note:
             The value is serialized before size checks are performed, so the
-            serialized size is what counts toward size limits.
+            serialized size is what counts toward size limits. If the serialized
+            value exceeds half the `size_limit_in_bytes`, it is silently dropped
+            without being stored.
         """
         serialized_value = self._serialize(value)
         super().set(key=key, value=serialized_value, ttl=ttl)

--- a/atomic_lru/_storage/storage.py
+++ b/atomic_lru/_storage/storage.py
@@ -245,8 +245,7 @@ class Storage(Generic[T]):
 
         Raises:
             RuntimeError: If the storage has been closed.
-            ValueError: If `size_limit_in_bytes` is set and `value` is not `bytes`,
-                or if the value is larger than half the size limit.
+            ValueError: If `size_limit_in_bytes` is set and `value` is not `bytes`.
 
         Note:
             Items larger than half the `size_limit_in_bytes` are rejected to prevent


### PR DESCRIPTION
## Summary

- The `Cache.set()` docstring incorrectly claimed a `ValueError` is raised when the serialized value exceeds half the `size_limit_in_bytes`; the actual behavior is a silent drop.
- The `Storage.set()` docstring had the same inaccuracy in its `Raises` section, despite the `Note` section already correctly describing the silent-drop behavior.
- Both docstrings are updated to match the actual implementation.

## Changes

- `atomic_lru/_cache.py` — `Cache.set()`: removed the oversized-value clause from `Raises`; added a sentence to the `Note` clarifying that oversized serialized values are silently dropped.
- `atomic_lru/_storage/storage.py` — `Storage.set()`: removed the "or if the value is larger than half the size limit" clause from `Raises`; the `Note` section already documented the correct behavior.

## Related issues

Closes #17

Made with [Cursor](https://cursor.com)