### PR TITLE
fix: preserve trailing newline in set-version.py

### DIFF
--- a/set-version.py
+++ b/set-version.py
@@ -18,8 +18,9 @@ def update_version_in_file(file: str, version: str):
         else:
             lines.append(line)
 
+    trailing_newline = "\n" if c.endswith("\n") else ""
     with open(file, "w") as g:
-        g.write("\n".join(lines))
+        g.write("\n".join(lines) + trailing_newline)
 
 
 def update_version(version: str, files: list[str]):


### PR DESCRIPTION
## Summary

- Fixes #35: `update_version_in_file()` was stripping trailing newlines from files
- Preserve the original trailing newline by checking if the file ended with `\n` before writing back

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (35 tests)

Made with [Cursor](https://cursor.com)