### PR TITLE
Fix missing input validation for max_items, default_ttl, and expiration_thread_delay in Storage

### DIFF
--- a/atomic_lru/_storage/storage.py
+++ b/atomic_lru/_storage/storage.py
@@ -101,6 +101,12 @@ class Storage(Generic[T]):
         # Validate configuration before allocating any resources
         if self.size_limit_in_bytes is not None and self.size_limit_in_bytes < 4096:
             raise ValueError("size_limit_in_bytes must be at least 4096")
+        if self.max_items is not None and self.max_items < 1:
+            raise ValueError("max_items must be at least 1")
+        if self.default_ttl is not None and self.default_ttl < 0:
+            raise ValueError("default_ttl cannot be negative")
+        if self.expiration_thread_delay <= 0:
+            raise ValueError("expiration_thread_delay must be positive")
 
         self._size_in_bytes = sys.getsizeof(self._data)
         if not self.expiration_disabled:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -414,6 +414,24 @@ def test_overwrite_existing_key_updates_lru_position_with_multiple_overwrites():
     storage.close()
 
 
+def test_storage_invalid_parameters():
+    """Test that invalid constructor parameters raise ValueError with clear messages."""
+    with pytest.raises(ValueError, match="max_items must be at least 1"):
+        Storage[bytes](max_items=0)
+
+    with pytest.raises(ValueError, match="max_items must be at least 1"):
+        Storage[bytes](max_items=-5)
+
+    with pytest.raises(ValueError, match="default_ttl cannot be negative"):
+        Storage[bytes](default_ttl=-1.0)
+
+    with pytest.raises(ValueError, match="expiration_thread_delay must be positive"):
+        Storage[bytes](expiration_thread_delay=0)
+
+    with pytest.raises(ValueError, match="expiration_thread_delay must be positive"):
+        Storage[bytes](expiration_thread_delay=-1.0)
+
+
 def test_overwrite_lru_item_size_tracking():
     """Size tracking stays correct when set() overwrites a key that gets evicted as the LRU item.
 


### PR DESCRIPTION
## Summary

- Adds `ValueError` in `Storage.__post_init__()` when `max_items < 1` (and not None), `default_ttl < 0` (and not None), or `expiration_thread_delay <= 0`
- Adds a `test_storage_invalid_parameters` test covering all new validation cases

Fixes #36

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (36 tests, including 5 new validation cases)

Made with [Cursor](https://cursor.com)