### PR TITLE
fix: validate expiration_thread_max_checks_per_iteration is not negative

### DIFF
--- a/atomic_lru/_storage/storage.py
+++ b/atomic_lru/_storage/storage.py
@@ -107,6 +107,10 @@ class Storage(Generic[T]):
             raise ValueError("default_ttl cannot be negative")
         if self.expiration_thread_delay <= 0:
             raise ValueError("expiration_thread_delay must be positive")
+        if self.expiration_thread_max_checks_per_iteration < 0:
+            raise ValueError(
+                "expiration_thread_max_checks_per_iteration cannot be negative"
+            )
 
         self._size_in_bytes = sys.getsizeof(self._data)
         if not self.expiration_disabled:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -431,6 +431,12 @@ def test_storage_invalid_parameters():
     with pytest.raises(ValueError, match="expiration_thread_delay must be positive"):
         Storage[bytes](expiration_thread_delay=-1.0)
 
+    with pytest.raises(
+        ValueError,
+        match="expiration_thread_max_checks_per_iteration cannot be negative",
+    ):
+        Storage[bytes](expiration_thread_max_checks_per_iteration=-1)
+
 
 def test_overwrite_lru_item_size_tracking():
     """Size tracking stays correct when set() overwrites a key that gets evicted as the LRU item.


### PR DESCRIPTION
## Summary

- Adds a `ValueError` in `Storage.__post_init__()` when `expiration_thread_max_checks_per_iteration` is negative, consistent with validation of other parameters
- Adds a test case to `test_storage_invalid_parameters` verifying the new validation

Closes #53

Made with [Cursor](https://cursor.com)