### PR TITLE
fix: add CACHE_MISS to Cache docstring example import

### DIFF
--- a/atomic_lru/_cache.py
+++ b/atomic_lru/_cache.py
@@ -116,7 +116,7 @@ class Cache(Storage[bytes]):
 
     Example:
         ```python
-        from atomic_lru import Cache
+        from atomic_lru import Cache, CACHE_MISS
         cache = Cache(max_items=100, default_ttl=3600)  # 1 hour TTL
         # Store any Python object
         cache.set("user:123", {"name": "Alice", "age": 30})


### PR DESCRIPTION
## Summary

- Fixes missing `CACHE_MISS` import in the `Cache` class docstring example
- The example code now correctly imports both `Cache` and `CACHE_MISS` so users can copy and run it without a `NameError`

Closes #47

## Test plan

- [x] `make lint` passes
- [x] `make test` passes
- [x] `make doc` passes

Made with [Cursor](https://cursor.com)